### PR TITLE
listfiles Example doesn't close files opened

### DIFF
--- a/examples/listfiles/listfiles.pde
+++ b/examples/listfiles/listfiles.pde
@@ -70,6 +70,7 @@ void printDirectory(File dir, int numTabs) {
        Serial.print("\t\t");
        Serial.println(entry.size(), DEC);
      }
+     entry.close(); // close file descriptor so we don't run out
    }
 }
 


### PR DESCRIPTION
I added an entry.close() at the bottom of the printDirectory loop. Otherwise, you run out of file descriptors after 26.
