### PR TITLE
Add fix for working with Teensy 3.2 board and make small changes to suppress compiler warnings.

### DIFF
--- a/utility/Sd2Card.cpp
+++ b/utility/Sd2Card.cpp
@@ -435,7 +435,6 @@ uint8_t Sd2Card::readBlock(uint32_t block, uint8_t* dst) {
  */
 uint8_t Sd2Card::readData(uint32_t block,
         uint16_t offset, uint16_t count, uint8_t* dst) {
-  uint16_t n;
   if (count == 0) return true;
   if ((count + offset) > 512) {
     goto fail;
@@ -465,7 +464,7 @@ uint8_t Sd2Card::readData(uint32_t block,
     SPDR = 0XFF;
   }
   // transfer data
-  n = count - 1;
+  uint16_t n = count - 1;
   for (uint16_t i = 0; i < n; i++) {
     while (!(SPSR & (1 << SPIF)));
     dst[i] = SPDR;
@@ -568,7 +567,7 @@ uint8_t Sd2Card::setSckRate(uint8_t sckRateID) {
   SPCR |= (sckRateID & 4 ? (1 << SPR1) : 0)
     | (sckRateID & 2 ? (1 << SPR0) : 0);
 #else // USE_SPI_LIB
-  int v;
+  int v = 0; // intialize to 0 so that the compiler does not issue a warning
 #ifdef SPI_CLOCK_DIV128
   switch (sckRateID) {
     case 0: v=SPI_CLOCK_DIV2; break;

--- a/utility/Sd2Card.cpp
+++ b/utility/Sd2Card.cpp
@@ -25,7 +25,7 @@
 #endif
 #include "Sd2Card.h"
 //------------------------------------------------------------------------------
-#ifdef __arm__
+#if defined(__arm__) && !defined(TEENSYDUINO)
 static int8_t mosiPin_, misoPin_, clockPin_;
 static volatile RwReg *mosiport, *clkport, *misoport;
 static uint32_t mosipinmask, clkpinmask, misopinmask;

--- a/utility/SdFile.cpp
+++ b/utility/SdFile.cpp
@@ -904,7 +904,7 @@ uint8_t SdFile::rmRfStar(void) {
       if (!f.remove()) return false;
     }
     // position to next entry if required
-    if (curPosition_ != (32*(index + 1))) {
+    if (curPosition_ != (32U*(index + 1U))) {
       if (!seekSet(32*(index + 1))) return false;
     }
   }


### PR DESCRIPTION
- Scope of changes:
  - The fix for Teensy 3.2 is a check for the `TEENSYDUINO` identifier which is defined at compile time for all Teensy 3 boards. The problem was being caused because for all ARM boards the `*mosiport, *clkport, *misoport` were defined as `static volatile RwReg` but that didn't work for the Teensy board, so now it falls back to the defining them as `static volatile uint8_t`.
  - The compiler warnings fixes are as following:
    - Inside the Sd2Card::setSckRate() function implementation, a variable
      `int v` is declared before a `#ifdef` directive, and assigned inside
      the directive statement. This caused the compiler to issue a **warning
      that the variable might be left uninitialized**. The variable is now
      initialized to 0.
    - Inside the Sd2Card::readData() function implementation, a variable
      `uint16_t n` is declared before a #ifdef directive, and assigned
      and used inside the directive statement. This caused the compiler
      to issue a **warning that the variable might be left unused**. The
      variable is now declared and assigned inside the #idfef directive.
    - Inside the SdFile::rmRfStar() function implementation, the following
      comparison is made `curPosition_ != (32*(index + 1))`. curPosition_ is
      of type `unit32_t` but the using of int constants in the right side
      of the comparison causes a compiler **warning that signed and unsigned
      integer types are being compared**. The integer constants are now written
      as unsigned.
- Known limitations: there are no know limitations that I'm aware of.
